### PR TITLE
Fix: destroy socket client to prevent re-calling callback

### DIFF
--- a/main.js
+++ b/main.js
@@ -330,7 +330,7 @@ function executeRequest(job, callback) {
     job.failed = true;
     job.error = "connection timed out";
     callback(job);
-    client.end();
+    client.destroy();
   });
 
   client.connect({


### PR DESCRIPTION
As outlined in #11 